### PR TITLE
remove prompts from mcp server to fix cursor

### DIFF
--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -124,7 +124,6 @@ export class TranslationMCPServer {
       capabilities: {
         tools: {},
         resources: {},
-        prompts: {}
       }
     });
 


### PR DESCRIPTION
stopped, working. removing this line + build fixes it.

found here: https://forum.cursor.com/t/cursor-v1-3-not-detecting-mcp-tools/124270/5